### PR TITLE
Single-bit std_logic to a slice (ghdl)

### DIFF
--- a/src/peakrdl_regblock_vhdl/readback/generators.py
+++ b/src/peakrdl_regblock_vhdl/readback/generators.py
@@ -248,7 +248,7 @@ class ReadbackAssignmentGenerator(RDLForLoopGenerator):
 
                 if field.width == 1:
                     # convert from std_logic to std_logic_vector
-                    value = f"({field.low} => {value})"
+                    value = f"to_std_logic_vector({value})"
                 self.add_content(f"readback_array({self.current_offset_str})({field.high} downto {field.low}) <= {value} when {rd_strb} else (others => '0');")
                 bidx = field.high + 1
 
@@ -317,7 +317,7 @@ class ReadbackAssignmentGenerator(RDLForLoopGenerator):
 
                     if field.width == 1:
                         # convert from std_logic to std_logic_vector
-                        value = f"({low} => {value})"
+                        value = f"to_std_logic_vector({value})"
                     self.add_content(f"readback_array({self.current_offset_str})({high} downto {low}) <= {value} when {rd_strb} else (others => '0');")
 
                     current_bit = field.high + 1


### PR DESCRIPTION
peakrdl-regblock-vhdl used (0 => value) when assigning single-bit std_logic to a slice, instead of (low => value), causing “choice is out of index range” when low != 0

This appear in ghdl, may not appear in other simulators

# Description of change

Fixes #27,

# Checklist

- [X] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock-vhdl/blob/main/CONTRIBUTING.md)
- [X] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)
- [X] If this change adds new features, I have added new unit tests that cover them.
