### PR TITLE
Added cpuif package_library property

### DIFF
--- a/src/peakrdl_regblock_vhdl/cpuif/base.py
+++ b/src/peakrdl_regblock_vhdl/cpuif/base.py
@@ -43,6 +43,10 @@ class CpuifBase:
         raise NotImplementedError()
 
     @property
+    def package_library(self) -> Union[str, None]:
+        return None
+
+    @property
     def parameters(self) -> List[str]:
         """
         Optional list of additional parameter declarations this CPU interface

--- a/src/peakrdl_regblock_vhdl/module_tmpl.vhd
+++ b/src/peakrdl_regblock_vhdl/module_tmpl.vhd
@@ -5,10 +5,14 @@ context ieee.ieee_std_context;
 use ieee.fixed_pkg.all;
 
 use work.{{ds.module_name}}_pkg.all;
-{%- if cpuif.package_name %}
+use work.reg_utils.all;
+{%- if cpuif.package_name and cpuif.package_library %}
+
+library {{cpuif.package_library}};
+use {{cpuif.package_library}}.{{cpuif.package_name}}.all;
+{%- elif cpuif.package_name %}
 use work.{{cpuif.package_name}}.all;
 {%- endif %}
-use work.reg_utils.all;
 
 entity {{ds.module_name}} is
     {%- if module_has_parameters() %}


### PR DESCRIPTION
Added a package_library property to the cpuif base class, to allow custom cpu interfaces to import the definitions from package_name (e.g. records) from a user specified library.

When this property is not overridden by a cpuif, it defaults to None and the "work" library is used as before.

# Description of change

See [Issue 43](https://github.com/SystemRDL/PeakRDL-regblock-vhdl/issues/43).

Unfortunately I was not able to run the unit tests locally. I manually tested the generator with the different combinations of package_name and package_library being set to a string or None.

Given that this just adds a property, I don't think a unit test for this feature would make sense.

# Checklist

- [ X ] I have reviewed this project's [contribution guidelines](https://github.com/SystemRDL/PeakRDL-regblock-vhdl/blob/main/CONTRIBUTING.md)
- [ X ] I have opened an issue to discuss the desired change.
- [ ] This change has been tested and does not break any of the existing unit tests. (if unable to run the tests, let us know)
- [ ] If this change adds new features, I have added new unit tests that cover them.

